### PR TITLE
Rspec

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,10 +27,8 @@ class ItemsController < ApplicationController
     if @item.save
       flash[:notice] = "Item saved"
       redirect_to user_items_path
-      
     else
       flash.now[:alert] = "There was a problem saving your item"
-      
     end
   
     #respond_to do |format| # for ajax
@@ -43,24 +41,20 @@ class ItemsController < ApplicationController
     @user = User.find(params[:user_id])
     @item = @user.items.find(params[:id])
     
-
     if @item.destroy
       flash[:notice] = "Item deleted"
-      
     else
       flash.now[:alert] = "There was a problem deleting your item"
-      
     end
     respond_to do |format| # for ajax
       format.html
       format.js
     end
   end
-  
+
   def edit
     @user = User.find(params[:user_id])
     @item = Item.find(params[:id])
-
   end
 
   def update
@@ -74,10 +68,8 @@ class ItemsController < ApplicationController
     if @item.save
       flash[:notice] = "Item was edited"
       redirect_to user_items_path
-      
     else
       flash.now[:alert] = "There was a problem editing your item"
-      
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,8 +36,9 @@ class ItemsController < ApplicationController
     #respond_to do |format| # for ajax
       #format.html
      # format.js
-  #end
-end
+    #end
+  end
+
   def destroy
     @user = User.find(params[:user_id])
     @item = @user.items.find(params[:id])
@@ -55,6 +56,7 @@ end
       format.js
     end
   end
+  
   def edit
     @user = User.find(params[:user_id])
     @item = Item.find(params[:id])
@@ -82,13 +84,8 @@ end
   def destroy_multiple
     @user = User.find(params[:user_id])
     @items = Item.where(id: params[:item_ids])
-    puts "trying to authorize"
     authorize @items
-    puts "authorized"
-    p @items
     if @items.destroy_all
-      puts "destroyed"
-      p @items
       flash[:notice] = "Items deleted"
       redirect_to :root
     else

--- a/app/policies/item_policy.rb
+++ b/app/policies/item_policy.rb
@@ -1,4 +1,4 @@
-class ItemPolicy < ApplicationPolicy
+class ItemPolicy
   attr_reader :current_user, :item
 
   def initialize(current_user, item)

--- a/app/policies/item_policy.rb
+++ b/app/policies/item_policy.rb
@@ -35,10 +35,7 @@ class ItemPolicy
   end
 
   def destroy_multiple?
-    items = item
-    items.each do |item|
-      return false if item.user != current_user
-    end
+    items = item  # actually contains a collection
+    items.all?{ |item| item.user == current_user }
   end
 end
-

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,6 +1,5 @@
-class UserPolicy < ApplicationPolicy
-
-attr_reader :current_user, :user
+class UserPolicy
+  attr_reader :current_user, :user
 
   def initialize(current_user, user)
     @current_user = current_user
@@ -35,4 +34,3 @@ attr_reader :current_user, :user
     false
   end
 end
-

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -43,9 +43,9 @@ describe ItemsController, type: :controller do
   end
 
   describe "DELETE destroy_multiple" do
-    let(:user_item_1) { user.items.create!(name: "an item") }
-    let(:user_item_2) { user.items.create!(name: "an item") }
-    let(:other_user_item) { other_user.items.create!(name: "an item") }
+    let!(:user_item_1) { user.items.create!(name: "an item") }
+    let!(:user_item_2) { user.items.create!(name: "an item") }
+    let!(:other_user_item) { other_user.items.create!(name: "an item") }
 
     context "when logged in as a user" do
       before do 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -42,7 +42,7 @@ describe ItemsController, type: :controller do
     end
   end
 
-  describe "DELETE #destroy_multiple" do
+  describe "DELETE destroy_multiple" do
     let(:user_item_1) { user.items.create!(name: "an item") }
     let(:user_item_2) { user.items.create!(name: "an item") }
     let(:other_user_item) { other_user.items.create!(name: "an item") }


### PR DESCRIPTION
I definitely had this in mind when we started writing the spec, but it got lost in all the other tangents:

RSpec `let` statements are "lazy": they only run when they're referenced for the first time.  If they're never referenced, they're never run.  If something happens before they're referenced for the first time (like, say, an `Item.count`), the things a `let` might later create (when referenced for the first time) won't yet exist in that world.

``` ruby
expect {
  delete :destroy_multiple, user_id: user.id, item_ids: [user_item_1.id, other_user_item.id]
}.to_not change(Item, :count)
```

aka

``` ruby
initial_count = Item.count
delete :destroy_multiple, user_id: user.id, item_ids: [user_item_1.id, other_user_item.id]
final_count   = Item.count
expect(final_count).to eq(initial_count)
```

`user_item_1` and `other_user_item` are only referenced, and thus only run (and the `Item`s they create, created), after this initial count is done:

---

``` ruby
initial_count = Item.count
```

The initial count is 0.

``` ruby
delete :destroy_multiple, user_id: user.id, item_ids: [user_item_1.id, other_user_item.id]
```

The 2 items are created, because the `let`s that create them are referenced for the first time.  
Then `destroy_multiple` is called: the authorization works as expected!  It rejects the request, and thus the destroy doesn't actually happen.

``` ruby
final_count   = Item.count
```

The final count is 2.

``` ruby
expect(final_count).to eq(initial_count)
```

That's why it says "expected Item count to not change, but it changed by +2": there are 2 new items that didn't exist then the initial count was made.
- The initial count is 0
- 2 items are created, we ask to destroy them, auth says no
- the final count is 2

And there's a similar problem with the other test (the one that's supposed to successfully delete stuff): it starts at 0, 2 items are created, 2 items are deleted, it ends at 0 -- reading no change, even though the deletes were authorized and did happen.

---

So, what we want to happen in this test:
- 2 items are created
- The initial count is 2
- we ask to destroy them, auth says no
- the final count is 2

We need to "force" the lazy `let` statements to run before taking our initial count.

One way to do that would be to just reference the things before doing anything else, like:

``` ruby
it "doesn't destroy anything" do
  user_item_1
  other_user_item
  expect {
    delete :destroy_multiple, user_id: user.id, item_ids: [user_item_1.id, other_user_item.id]
  }.to_not change(Item, :count)
end
```

Or we could put that in a `before` block:

``` ruby
before {
  user_item_1
  other_user_item
}

it "doesn't destroy anything" do
  expect {
    delete :destroy_multiple, user_id: user.id, item_ids: [user_item_1.id, other_user_item.id]
  }.to_not change(Item, :count)
end
```

Or, we could use an alternate version of `let`:

`let!` (with a `!`) is a "non-lazy" let, which will run before the test no matter what (like a `let` and a `before` block, in one).

So:

``` ruby
let(:user_item_1) { user.items.create!(name: "an item") }
let(:user_item_2) { user.items.create!(name: "an item") }
let(:other_user_item) { other_user.items.create!(name: "an item") }
```

becomes

``` ruby
let!(:user_item_1) { user.items.create!(name: "an item") }
let!(:user_item_2) { user.items.create!(name: "an item") }
let!(:other_user_item) { other_user.items.create!(name: "an item") }
```

and the tests pass!

That's what this Pull Request changes: it just adds those `!`s (and makes some other small, mostly stylistic changes -- but you should review them anyway)
